### PR TITLE
Add instructions to run autoencoder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,19 @@ Finally, start Jupyter:
 
     $ jupyter notebook
 
+Alternatively you can run the helper script to install Miniconda and
+create the environment in one go:
+
+    $ bash scripts/setup_conda.sh
+
 If you need further instructions, read the [detailed installation instructions](INSTALL.md).
+
+To run the example autoencoder script and generate a loss curve image:
+
+    $ python scripts/autoencoder_complex.py
+
+The training and validation loss curves will be saved to `loss_curve.png` and the
+script will print the reconstruction error on the validation set.
 
 # FAQ
 

--- a/scripts/autoencoder_complex.py
+++ b/scripts/autoencoder_complex.py
@@ -1,0 +1,78 @@
+import numpy as np
+from sklearn.model_selection import train_test_split
+import matplotlib.pyplot as plt
+from tensorflow import keras
+
+
+def generate_signals(n_samples=5000, length=200, noise=0.1):
+    """Generate synthetic 1D signals made of two sine waves plus noise."""
+    t = np.linspace(0, 1, length)
+    signals = []
+    for _ in range(n_samples):
+        freq1 = np.random.uniform(1, 5)
+        freq2 = np.random.uniform(6, 12)
+        amp1 = np.random.uniform(0.5, 1.0)
+        amp2 = np.random.uniform(0.5, 1.0)
+        phase1 = np.random.uniform(0, 2 * np.pi)
+        phase2 = np.random.uniform(0, 2 * np.pi)
+        signal = (
+            amp1 * np.sin(2 * np.pi * freq1 * t + phase1)
+            + amp2 * np.sin(2 * np.pi * freq2 * t + phase2)
+        )
+        signal += noise * np.random.randn(length)
+        signals.append(signal.astype(np.float32))
+    return np.array(signals)
+
+
+def build_autoencoder(input_dim):
+    """Create a slightly larger autoencoder model."""
+    model = keras.Sequential([
+        keras.layers.InputLayer(input_shape=(input_dim,)),
+        keras.layers.Dense(128, activation="selu"),
+        keras.layers.Dense(64, activation="selu"),
+        keras.layers.Dense(32, activation="selu"),
+        keras.layers.Dense(16, activation="selu", name="latent"),
+        keras.layers.Dense(32, activation="selu"),
+        keras.layers.Dense(64, activation="selu"),
+        keras.layers.Dense(128, activation="selu"),
+        keras.layers.Dense(input_dim),
+    ])
+    model.compile(optimizer="adam", loss="mse")
+    return model
+
+
+def main():
+    # Generate more complex synthetic data
+    signals = generate_signals()
+    X_train, X_valid = train_test_split(signals, test_size=0.2, random_state=42)
+
+    model = build_autoencoder(signals.shape[1])
+
+    history = model.fit(
+        X_train,
+        X_train,
+        epochs=30,
+        batch_size=32,
+        validation_data=(X_valid, X_valid),
+        verbose=2,
+    )
+
+    # Plot loss curves
+    plt.figure(figsize=(8, 4))
+    plt.plot(history.history["loss"], label="train")
+    plt.plot(history.history["val_loss"], label="validation")
+    plt.xlabel("Epoch")
+    plt.ylabel("MSE")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig("loss_curve.png")
+    plt.show()
+
+    # Compute reconstruction error on the validation set
+    reconstructions = model.predict(X_valid)
+    mse = np.mean(np.square(reconstructions - X_valid))
+    print(f"Reconstruction MSE on validation set: {mse:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_conda.sh
+++ b/scripts/setup_conda.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script installs Miniconda and creates the 'tf2' conda environment
+# defined in environment.yml. It is intended for reproducing the environment
+# used in the Hands-on Machine Learning project.
+
+set -e
+
+ENV_NAME="${1:-tf2}"
+MINICONDA_DIR="$HOME/miniconda3"
+
+# Download and install Miniconda if it is not already installed
+if [ ! -x "$MINICONDA_DIR/bin/conda" ]; then
+  echo "Installing Miniconda to $MINICONDA_DIR..."
+  curl -L -o /tmp/miniconda.sh "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+  bash /tmp/miniconda.sh -b -p "$MINICONDA_DIR"
+  rm /tmp/miniconda.sh
+fi
+
+export PATH="$MINICONDA_DIR/bin:$PATH"
+
+# Initialize conda (needed if running non-interactively)
+source "$MINICONDA_DIR/etc/profile.d/conda.sh"
+
+# Create the environment from environment.yml
+conda env create -f environment.yml -n "$ENV_NAME"
+
+echo "\nEnvironment '$ENV_NAME' created. Activate it with:\n"
+echo "  source $MINICONDA_DIR/bin/activate $ENV_NAME"


### PR DESCRIPTION
## Summary
- mention `setup_conda.sh` script in README
- add run instructions for `autoencoder_complex.py`
- save the loss curves to `loss_curve.png`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b67b61fd88331aec5ff4da5c57af3